### PR TITLE
fix floating number issue

### DIFF
--- a/src/HMRC/VAT/SubmitVATReturnPostBody.php
+++ b/src/HMRC/VAT/SubmitVATReturnPostBody.php
@@ -84,15 +84,15 @@ class SubmitVATReturnPostBody implements PostBody
     {
         return [
             'periodKey'                    => $this->periodKey,
-            'vatDueSales'                  => $this->vatDueSales,
-            'vatDueAcquisitions'           => $this->vatDueAcquisitions,
-            'totalVatDue'                  => $this->totalVatDue,
-            'vatReclaimedCurrPeriod'       => $this->vatReclaimedCurrPeriod,
-            'netVatDue'                    => $this->netVatDue,
-            'totalValueSalesExVAT'         => $this->totalValueSalesExVAT,
-            'totalValuePurchasesExVAT'     => $this->totalValuePurchasesExVAT,
-            'totalValueGoodsSuppliedExVAT' => $this->totalValueGoodsSuppliedExVAT,
-            'totalAcquisitionsExVAT'       => $this->totalAcquisitionsExVAT,
+            'vatDueSales'                  => (string) $this->vatDueSales,
+            'vatDueAcquisitions'           => (string) $this->vatDueAcquisitions,
+            'totalVatDue'                  => (string) $this->totalVatDue,
+            'vatReclaimedCurrPeriod'       => (string) $this->vatReclaimedCurrPeriod,
+            'netVatDue'                    => (string) $this->netVatDue,
+            'totalValueSalesExVAT'         => (string) $this->totalValueSalesExVAT,
+            'totalValuePurchasesExVAT'     => (string) $this->totalValuePurchasesExVAT,
+            'totalValueGoodsSuppliedExVAT' => (string) $this->totalValueGoodsSuppliedExVAT,
+            'totalAcquisitionsExVAT'       => (string) $this->totalAcquisitionsExVAT,
             'finalised'                    => $this->finalised,
         ];
     }


### PR DESCRIPTION
in some versions of PHP 7.1 json_encode converts float numbers to something like 16.9900000000004. In such case HMRC service objects that money is not in correct format 99,999,999,999.99